### PR TITLE
Solidity 0.5.0 (#1)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules
+/public

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "mocha": true,
+    "node": true
+  },
+  "extends": [
+    "airbnb-base"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "rules": {
+    "arrow-parens": ["error", "always"],
+    "comma-dangle": ["error", "never"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install ethereum-localized-messaging
 Implement your own localizations:
 
 ```solidity
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 import "/ethereum-localized-messaging/contracts/Localization.sol";
 
@@ -42,7 +42,7 @@ contract PirateLocalization is Localization {
 ```
 
 ```solidity
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 import "/ethereum-localized-messaging/contracts/LocalizationPreferences.sol";
 import "./PirateLocalization.sol";

--- a/contracts/Localization.sol
+++ b/contracts/Localization.sol
@@ -1,22 +1,26 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 /// @title Holds a simple mapping of codes to their text representations
 contract Localization {
-    mapping(bytes32 => string) internal dictionary_;
+    mapping(bytes32 => string) internal dictionary;
 
     constructor() public {}
 
     /// @notice Sets a mapping of a code to its text representation
-    /// @param _code The code with which to associate the text
-    /// @param _message The text representation
-    function set(bytes32 _code, string _message) internal {
-        dictionary_[_code] = _message;
+    /// @param code The code with which to associate the text
+    /// @param message The text representation
+    function set(bytes32 code, string memory message) internal {
+        dictionary[code] = message;
+    }
+
+    function set(bytes32 code, string storage message) internal {
+        dictionary[code] = message;
     }
 
     /// @notice Fetches the localized text representation.
-    /// @param _code The code to lookup
+    /// @param code The code to lookup
     /// @return The text representation for given code, or an empty string
-    function textFor(bytes32 _code) external view returns (string _message) {
-        return dictionary_[_code];
+    function textFor(bytes32 code) external view returns (string memory message) {
+        return dictionary[code];
     }
 }

--- a/contracts/LocalizationPreferences.sol
+++ b/contracts/LocalizationPreferences.sol
@@ -1,12 +1,13 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "./Localization.sol";
 
 /// @title A proxy contract that allows users to set their preferred Localization
 contract LocalizationPreferences {
-    mapping(address => Localization) private registry_;
+    bytes32 private EMPTY = keccak256(abi.encodePacked(""));
+
     Localization public defaultLocalization;
-    bytes32 private empty_ = keccak256(abi.encodePacked(""));
+    mapping(address => Localization) private registry;
 
     constructor(Localization _defaultLocalization) public {
         defaultLocalization = _defaultLocalization;
@@ -14,34 +15,34 @@ contract LocalizationPreferences {
 
     /// @notice Registers a user’s preferred Localization
     /// @dev The registering user is considered tx.origin
-    /// @param _localization The localization to set for the registering user
-    function set(Localization _localization) external {
-        registry_[tx.origin] = _localization;
+    /// @param localization The localization to set for the registering user
+    function set(Localization localization) external {
+        registry[tx.origin] = localization;
     }
 
     /// @dev Primarily for testing
-    function get(bytes32 _code, address _who) public view returns (bool, string) {
-        string memory text = getLocalizationFor(_who).textFor(_code);
+    function get(bytes32 code, address who) public view returns (bool found, string memory text) {
+        string memory _text = getLocalizationFor(who).textFor(code);
 
-        if (keccak256(abi.encodePacked(text)) != empty_) {
-            return (true, text);
+        if (keccak256(abi.encodePacked(_text)) != EMPTY) {
+            return (true, _text);
         } else {
-            return (false, defaultLocalization.textFor(_code));
+            return (false, defaultLocalization.textFor(code));
         }
     }
 
     /// @notice Retrieve text for a code found at the user’s preferred Localization contract
-    /// @param _code The code to use to retrieve the text representation
+    /// @param code The code to use to retrieve the text representation
     /// @return (bool, string) tuple: true if found and false otherwise, the corresponding message or default message or empty string
-    function textFor(bytes32 _code) external view returns (bool, string) {
-        return get(_code, tx.origin);
+    function textFor(bytes32 code) external view returns (bool found, string memory text) {
+        return get(code, tx.origin);
     }
 
-    function getLocalizationFor(address _who) internal view returns (Localization) {
-        if (Localization(registry_[_who]) == Localization(0)) {
+    function getLocalizationFor(address who) internal view returns (Localization) {
+        if (Localization(registry[who]) == Localization(0)) {
             return Localization(defaultLocalization);
         } else {
-            return Localization(registry_[tx.origin]);
+            return Localization(registry[tx.origin]);
         }
     }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/localizationExamples/PirateLocalization.sol
+++ b/contracts/localizationExamples/PirateLocalization.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "../Localization.sol";
 

--- a/contracts/localizationExamples/SpanishLocalization.sol
+++ b/contracts/localizationExamples/SpanishLocalization.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "../Localization.sol";
 

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
-var Migrations = artifacts.require("./Migrations.sol");
+const Migrations = artifacts.require('./Migrations.sol');
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.deploy(Migrations);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-localized-messaging",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A method of converting machine codes to human-readable text in any language and phrasing.",
   "keywords": [
     "ethereum",
@@ -39,23 +39,23 @@
     }
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "eslint": "^5.6.0",
+    "chai": "^4.2.0",
+    "eslint": "^5.12.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.9.0",
-    "ganache-cli": "^6.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "ganache-cli": "^6.2.5",
     "mocha": "^5.2.0",
-    "npm-watch": "^0.4.0",
+    "npm-watch": "^0.5.0",
     "openzeppelin-solidity": "^1.12.0",
-    "solhint": "^1.1.10",
+    "solhint": "^1.5.0",
     "solidity-coverage": "^0.5.11"
   },
   "engines": {
     "node": ">=8.4"
   },
   "dependencies": {
-    "ethereumjs-tx": "^1.3.4",
-    "truffle": "^5.0.0-beta.00",
-    "web3": "^1.0.0-beta.36"
+    "ethereumjs-tx": "^1.3.7",
+    "truffle": "^5.0.1",
+    "web3": "^1.0.0-beta.37"
   }
 }

--- a/test/LocalizationPreferencesTests.js
+++ b/test/LocalizationPreferencesTests.js
@@ -1,6 +1,6 @@
-var LocalizationPreferences = artifacts.require('LocalizationPreferences.sol');
-var PirateLocalization = artifacts.require('PirateLocalization.sol');
-var SpanishLocalization = artifacts.require('SpanishLocalization.sol');
+const LocalizationPreferences = artifacts.require('LocalizationPreferences.sol');
+const PirateLocalization = artifacts.require('PirateLocalization.sol');
+const SpanishLocalization = artifacts.require('SpanishLocalization.sol');
 
 contract('LocalizationPreferencesTests', async (accounts) => {
   let defaultLocalization;
@@ -18,15 +18,25 @@ contract('LocalizationPreferencesTests', async (accounts) => {
       await localizationPreferences.set(spanishLocalization.address);
       const result = await localizationPreferences.get(web3.utils.toHex('0x02'), accounts[0]);
 
-      expect(result).to.eql({'0': true, '1': 'Aceptado/Iniciado'});
+      expect(result).to.eql({
+        0:     true,
+        found: true,
+        1:     'Aceptado/Iniciado',
+        text:  'Aceptado/Iniciado'
+      });
     });
   });
 
   describe('#textFor', async () => {
     it('uses the default localization when none has been set', async () => {
-      const result = await localizationPreferences.textFor(web3.utils.toHex('0x02'), {from: accounts[3]});
+      const result = await localizationPreferences.textFor(web3.utils.toHex('0x02'), { from: accounts[3] });
 
-      expect(result).to.eql({'0': true, '1': 'Arr jolly crew have begun'});
+      expect(result).to.eql({
+        0:     true,
+        found: true,
+        1:     'Arr jolly crew have begun',
+        text:  'Arr jolly crew have begun'
+      });
     });
 
     context('with a localization already set', async () => {
@@ -34,21 +44,36 @@ contract('LocalizationPreferencesTests', async (accounts) => {
         await localizationPreferences.set(spanishLocalization.address);
         const result = await localizationPreferences.textFor(web3.utils.toHex('0x01'));
 
-        expect(result).to.eql({'0': true, '1': 'Éxito'});
+        expect(result).to.eql({
+          0:     true,
+          found: true,
+          1:     'Éxito',
+          text:  'Éxito'
+        });
       });
     });
 
     it('returns false and an empty string if no code matches any localizations', async () => {
       const result = await localizationPreferences.textFor(web3.utils.toHex('0x12'));
 
-      expect(result).to.eql({'0': false, '1': ''});
+      expect(result).to.eql({
+         0:     false,
+         found: false,
+         1:     '',
+         text:  ''
+      });
     });
 
     it('falls back to the default localization', async () => {
       await localizationPreferences.set(spanishLocalization.address);
       const result = await localizationPreferences.textFor(web3.utils.toHex('0x05'));
 
-      expect(result).to.eql({'0': false, '1': 'Has walked thar plank an expired'});
+      expect(result).to.eql({
+         0:     false,
+         found: false,
+         1:     'Has walked thar plank an expired',
+         text:  'Has walked thar plank an expired'
+      });
     });
   });
 });

--- a/test/LocalizationTests.js
+++ b/test/LocalizationTests.js
@@ -1,16 +1,16 @@
-var PirateLocalization = artifacts.require("PirateLocalization.sol");
+const PirateLocalization = artifacts.require('PirateLocalization.sol');
 
-contract("LocalizationTests", async (accounts) => {
+contract('LocalizationTests', async (accounts) => {
   let localizationInstance;
 
-  before("setup", async () => {
+  before('setup', async () => {
     localizationInstance = await PirateLocalization.new();
   });
 
-  describe("#get", async () => {
-    it("gets text for a given code", async () => {
-      const result = await localizationInstance.textFor(web3.utils.toHex("0x01"));
-      expect(result).to.equal("Aye!");
+  describe('#get', async () => {
+    it('gets text for a given code', async () => {
+      const result = await localizationInstance.textFor(web3.utils.toHex('0x01'));
+      expect(result).to.equal('Aye!');
     });
   });
 });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -47,9 +47,9 @@ module.exports = {
     // options below to some value.
     //
     development: {
-     host: "127.0.0.1",     // Localhost (default: none)
-     port: 8545,            // Standard Ethereum port (default: none)
-     network_id: "*",       // Any network (default: none)
+      host: '127.0.0.1', // Localhost (default: none)
+      port: 8545, // Standard Ethereum port (default: none)
+      network_id: '*' // Any network (default: none)
     },
 
     // Another network with more advanced options...
@@ -89,7 +89,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.5.0",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {
@@ -100,4 +100,4 @@ module.exports = {
       // }
     }
   }
-}
+};


### PR DESCRIPTION
Update Solidity to 0.5.0 and change conventions to the _new_ old conventions (🤦‍♀️)

This fixes issues for FISSION helper libs upgrading to Solidity 0.5.x